### PR TITLE
Add ability to partially grab memory

### DIFF
--- a/ds1054z/__init__.py
+++ b/ds1054z/__init__.py
@@ -319,7 +319,6 @@ class DS1054Z(vxi11.Instrument):
             end_pos = min(pos + pnts, pos+max_byte_len-1)
             self.write(":WAVeform:STOP {0}".format(end_pos))
             tmp_buff = self.query_raw(":WAVeform:DATA?")
-            print len(tmp_buff)
             buff += DS1054Z.decode_ieee_block(tmp_buff)
             pos += max_byte_len
         return buff


### PR DESCRIPTION
Now you can scope.get_waveform_samples(start=5,end=5000). Hooray!